### PR TITLE
feat: improve mobile navigation and project card layout

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,21 +1,24 @@
-import { Moon, Sun } from "lucide-react";
+import { BookOpen, FolderKanban, Home, Moon, Sun, UserRound } from "lucide-react";
 import { useTheme } from "next-themes";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
-const listMenu: Array<{ name: string; link: string }> = [
+const listMenu: Array<{ name: string; link: string; icon: typeof Home }> = [
   {
     name: "About",
     link: "/about",
+    icon: UserRound,
   },
   {
     name: "Blog",
     link: "/blog",
+    icon: BookOpen,
   },
   {
     name: "Projects",
     link: "/projects",
+    icon: FolderKanban,
   },
 ];
 
@@ -51,25 +54,31 @@ export default function Navbar() {
             <Link
               className={
                 router.pathname === "/"
-                  ? `py-2 px-4 text-primary font-bold text-sm transition-all duration-300 relative after:absolute after:bottom-1 after:left-1/2 after:-translate-x-1/2 after:w-1 after:h-1 after:bg-primary after:rounded-full`
-                  : `py-2 px-4 text-zinc-600 dark:text-zinc-400 hover:text-primary font-semibold text-sm transition-all duration-300 hover:scale-105`
+                  ? `py-2 px-3 md:px-4 text-primary font-bold text-sm transition-all duration-300 relative after:absolute after:bottom-1 after:left-1/2 after:-translate-x-1/2 after:w-1 after:h-1 after:bg-primary after:rounded-full`
+                  : `py-2 px-3 md:px-4 text-zinc-600 dark:text-zinc-400 hover:text-primary font-semibold text-sm transition-all duration-300 hover:scale-105`
               }
-              href={"/"}
+              href="/"
+              aria-label="Home"
             >
-              Home
+              <Home size={18} className="md:hidden" />
+              <span className="hidden md:inline">Home</span>
             </Link>
             {listMenu.map((list) => {
+              const Icon = list.icon;
+
               return (
                 <Link
                   className={
                     router.pathname.startsWith(list.link)
-                      ? `py-2 px-4 text-primary font-bold text-sm transition-all duration-300 relative after:absolute after:bottom-1 after:left-1/2 after:-translate-x-1/2 after:w-1 after:h-1 after:bg-primary after:rounded-full`
-                      : `py-2 px-4 text-zinc-600 dark:text-zinc-400 hover:text-primary font-semibold text-sm transition-all duration-300 hover:scale-105`
+                      ? `py-2 px-3 md:px-4 text-primary font-bold text-sm transition-all duration-300 relative after:absolute after:bottom-1 after:left-1/2 after:-translate-x-1/2 after:w-1 after:h-1 after:bg-primary after:rounded-full`
+                      : `py-2 px-3 md:px-4 text-zinc-600 dark:text-zinc-400 hover:text-primary font-semibold text-sm transition-all duration-300 hover:scale-105`
                   }
                   href={list.link}
                   key={list.name}
+                  aria-label={list.name}
                 >
-                  {list.name}
+                  <Icon size={18} className="md:hidden" />
+                  <span className="hidden md:inline">{list.name}</span>
                 </Link>
               );
             })}

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -103,7 +103,7 @@ export default function ProjectCard({ name, description, link, image }) {
       className="group relative flex flex-col md:flex-row gap-8 p-6 my-4 bg-transparent transition-all duration-500 rounded-3x"
     >
       {/* content */}
-      <div className="flex flex-col justify-center flex-grow py-2">
+      <div className="order-2 flex flex-col justify-center flex-grow py-2 md:order-1">
         <div className="mb-1">
           <h3 className="text-2xl font-extrabold tracking-tight text-zinc-900 dark:text-zinc-100 group-hover:text-primary transition-colors duration-300">
             {name}
@@ -146,7 +146,7 @@ export default function ProjectCard({ name, description, link, image }) {
       </div>
 
       {/* image container */}
-      <div className="w-full md:w-64 h-40 shrink-0 relative overflow-hidden rounded-2xl bg-zinc-100 dark:bg-zinc-900 shadow-sm transition-all duration-500 group-hover:shadow-2xl group-hover:shadow-primary/20 transition-all duration-700 group-hover:scale-110 group-hover:rotate-1">
+      <div className="order-1 w-full md:w-64 h-40 shrink-0 relative overflow-hidden rounded-2xl bg-zinc-100 dark:bg-zinc-900 shadow-sm transition-all duration-500 group-hover:shadow-2xl group-hover:shadow-primary/20 transition-all duration-700 group-hover:scale-110 group-hover:rotate-1 md:order-2">
         {image && image[0] ? (
           <button
             onClick={() => setZoomed(true)}

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -14,7 +14,7 @@ export default function index({ projects }: ProjectProps) {
       <Head>
         <title>Projects | Syakirin Amin</title>
       </Head>
-      <div className="py-12 px-4">
+      <div className="max-w-4xl mx-auto py-12 px-4">
         <div className="mb-12 max-w-2xl">
           <h1 className="text-4xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100 mb-4">
             Projects
@@ -26,7 +26,7 @@ export default function index({ projects }: ProjectProps) {
           <div className="mt-6 w-20 h-1 bg-primary"></div>
         </div>
 
-        <div className="flex flex-col gap-2">
+        <div className="flex max-w-4xl flex-col gap-2">
           {projects &&
             projects.map((post) => {
               return (


### PR DESCRIPTION
## Summary
- make the navbar render icons only on mobile while keeping text labels on desktop
- align the projects page content width with the parent max-width container
- move project images to the top on mobile while preserving the desktop side-by-side layout

## Validation
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added icons to navigation menu items for improved visual guidance.

* **Style**
  * Improved responsive layouts for navigation and project cards across mobile and desktop viewports.
  * Optimized spacing and padding adjustments for better consistency.

* **Accessibility**
  * Added aria-labels to navigation links for enhanced screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->